### PR TITLE
更新 INSTALL-ubuntu.md，添加安装 imagemagick

### DIFF
--- a/doc/INSTALL-ubuntu.md
+++ b/doc/INSTALL-ubuntu.md
@@ -5,7 +5,7 @@ Install Ruby 2.0 by rvm or rbenv.
 ### Development Environment
 
 ```bash
-sudo apt-get install mongodb memcached redis-server pandoc
+sudo apt-get install mongodb memcached redis-server pandoc imagemagick
 
 git clone https://github.com/chloerei/writings.git
 cd writings


### PR DESCRIPTION
Mini_magick gem 默认配置下依赖外部程序 ImageMagick，因而在安装向导文档里面需要添加对 imagemagick 的安装。

See: https://github.com/minimagick/minimagick#requirements
