### PR TITLE
登录成功后，改为直接跳转页面，从而 Safari 浏览器可以正确提示用户保存密码。

### DIFF
--- a/app/views/user_sessions/create.js.erb
+++ b/app/views/user_sessions/create.js.erb
@@ -1,5 +1,5 @@
 <% if logined? %>
-  Turbolinks.visit('<%= j(session.delete(:return_to) || root_url) %>');
+  window.location = '<%= j(session.delete(:return_to) || root_url) %>';
 <% else %>
   Turbolinks.visit('<%= login_url %>');
 <% end %>


### PR DESCRIPTION
当前版本的行为是在登录成功之后，使用 Turbolinks 来无刷新跳转到登陆后页面。

那么，使用 OS X Safari，开启「设置」-「密码」-「自动填充用户名和密码」的话：
1. 点击登录链接
2. 输入正确的用户名和密码，点击登录按钮，提交表单，等待浏览器加载新的页面
3. 按浏览器的刷新按钮或者键盘快捷键 Cmd+R 刷新当前页面

会看到浏览器提示是否要保存密码到钥匙串以供以后使用。而用户期待的情形会是在第 2 步成功登录之后，浏览器就出现保存密码的提示。

将登录成功之后的行为改为直接使用 Javascript `window.location=` 来跳转页面可以在此时触发浏览器的保存密码提示。
