### PR TITLE
set httponly to remember_me's cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -128,7 +128,8 @@ class ApplicationController < ActionController::Base
   def remember_me
     cookies[:remember_token] = {
       :value   => current_user.remember_token,
-      :expires => 2.weeks.from_now
+      :expires => 2.weeks.from_now,
+      :httponly => true
     }
   end
 end


### PR DESCRIPTION
给 cookies[:remember_token] 设置httponly，防止潜在的Cookie Theft攻击。
